### PR TITLE
Adjust permission for deploying docs to gh-pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ env:
 jobs:
   build:
     name: Build vocabulary & documentation
+    permissions:
+      # Required for peaceiris/actions-gh-pages below
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -45,8 +48,8 @@ jobs:
           ls -l publish/ || echo "publish directory does not exist."
 
       - name: Deploy documentation
-        # Pin third party action (v3.9.2)
-        uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
+        # Pin third party action (v3.9.3)
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages


### PR DESCRIPTION
Includes an update of `peaceiris/actions-gh-pages` to latest version 3.9.3.

Closes #21