### PR TITLE
Install tagged version of voc4cat-tool in CI (v0.5.1)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -57,7 +57,11 @@ jobs:
           python -VV
           python -m pip install --upgrade pip setuptools wheel
 
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
+          # install tagged version
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.5.1
+
+          # examples for other install options
+          # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
           # from private repo: python -m pip install git+https://anon:${{ SECRETS.READ_PAT_VOC4CAT }}@github.com/dalito/voc4cat-tool.git@main
 
       - name: Dynamically set RUN_DATE environment variable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -VV
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.5.1
 
       - name: Run voc4cat to build docs & Excel-files matching turtle files
         run: |


### PR DESCRIPTION
...instead of current main to prevent breaking gh-action pipelines by accident.