### PR TITLE
Update merge.yml to publish on manual dispatch

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -88,7 +88,7 @@ jobs:
         # content and just re-publish the extended version.
         # Pin third party action (v3.9.3)
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sometimes one wants to trigger an documentation update (e.g. after a change to pylode). For this uses case it is important to publish also on manually triggered runs.