### PR TITLE
Change to fetch-depth 0 to get all tags

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -32,6 +32,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Using fetch-depth 0 is the only way to get all tags which are needed for building docs.
+          fetch-depth: 0
 
       - name: Checkout gh-pages branch to dir publish/
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Using fetch-depth 0 is the only way to get all tags which are needed for building docs.
+          fetch-depth: 0
 
       - name: Checkout gh-pages branch to dir publish/
         uses: actions/checkout@v3


### PR DESCRIPTION
The checkout action does not checkout tags by default (see e.g. https://github.com/actions/checkout/issues/290). As a consequence the documentation lacks tagged versions on the `index.html` page. The solution is to checkout the full history including the tags by setting:

```yaml
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0
```
