### PR TITLE
Update ttl-files of vocab_example to vocpub 4.5

### DIFF
--- a/vocabularies/vocab_example/0000001.ttl
+++ b/vocabularies/vocab_example/0000001.ttl
@@ -6,10 +6,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://example.org/test/0000001>
     a skos:Concept ;
     dcterms:identifier "0000001"^^xsd:token ;
-    dcterms:provenance "0000-0001-2345-6789 Created concept"@en ;
     rdfs:isDefinedBy <https://datatracker.ietf.org/doc/html/rfc2396> ;
     skos:altLabel "URI"@en ;
     skos:definition "Uniform Resource Identifier is a compact string of characters for identifying an abstract or physical resource."@en ;
+    skos:historyNote "0000-0001-2345-6789 Created concept"@en ;
     skos:inScheme <https://example.org/test/> ;
     skos:narrower <https://example.org/test/0000002> ;
     skos:prefLabel "Uniform Resource Identifier"@en ;

--- a/vocabularies/vocab_example/0000002.ttl
+++ b/vocabularies/vocab_example/0000002.ttl
@@ -6,13 +6,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://example.org/test/0000002>
     a skos:Concept ;
     dcterms:identifier "0000002"^^xsd:token ;
-    dcterms:provenance "0000-0001-2345-6789 Created concept"@en ;
     rdfs:isDefinedBy <https://www.w3.org/TR/2010/NOTE-curie-20101216/> ;
     skos:altLabel
         "CURIE"@en ,
         "CompactURI"@en ;
     skos:broader <https://example.org/test/0000001> ;
     skos:definition "A CURIE (or Compact URI) defines a generic, abbreviated syntax for expressing Uniform Resource Identifiers (URIs). "@en ;
+    skos:historyNote "0000-0001-2345-6789 Created concept"@en ;
     skos:inScheme <https://example.org/test/> ;
     skos:prefLabel "Compact Universal Resource Locator"@en ;
 .

--- a/vocabularies/vocab_example/0000003.ttl
+++ b/vocabularies/vocab_example/0000003.ttl
@@ -6,10 +6,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://example.org/test/0000003>
     a skos:Concept ;
     dcterms:identifier "0000003"^^xsd:token ;
-    dcterms:provenance "0000-0001-2345-6789 Created concept"@en ;
     rdfs:isDefinedBy <https://datatracker.ietf.org/doc/html/rfc3987> ;
     skos:altLabel "IRI"@en ;
     skos:definition "Internationalized Resource Identifier (IRI) is an internet protocol standard which builds on the Uniform Resource Identifier (URI) protocol by greatly expanding the set of permitted characters."@en ;
+    skos:historyNote "0000-0001-2345-6789 Created concept"@en ;
     skos:inScheme <https://example.org/test/> ;
     skos:prefLabel "Internationalized Resource Identifier"@en ;
     skos:topConceptOf <https://example.org/test/> ;

--- a/vocabularies/vocab_example/0000010.ttl
+++ b/vocabularies/vocab_example/0000010.ttl
@@ -1,4 +1,5 @@
 PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -6,8 +7,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Collection ;
     dcterms:identifier "0000010"^^xsd:token ;
     dcterms:isPartOf <https://example.org/test/> ;
-    dcterms:provenance "0000-0001-2345-6789 Created collection"@en ;
+    rdfs:isDefinedBy <https://example.org/test/> ;
     skos:definition "Collection of terms related to linked data."@en ;
+    skos:historyNote "0000-0001-2345-6789 Created collection"@en ;
+    skos:inScheme <https://example.org/test/> ;
     skos:member
         <https://example.org/test/0000001> ,
         <https://example.org/test/0000002> ,

--- a/vocabularies/vocab_example/concept_scheme.ttl
+++ b/vocabularies/vocab_example/concept_scheme.ttl
@@ -11,13 +11,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:hasPart <https://example.org/test/0000010> ;
     dcterms:identifier ""^^xsd:token ;
     dcterms:modified "2023-03-10"^^xsd:date ;
-    dcterms:provenance "https://orcid.org/0000-0001-2345-6789 Sofia Garcia"@en ;
     dcterms:publisher <http://example.org/nfdi4cat/> ;
     owl:versionInfo "v2023-03-10" ;
     skos:definition "A test vocabulary for the voc4cat template"@en ;
     skos:hasTopConcept
         <https://example.org/test/0000001> ,
         <https://example.org/test/0000003> ;
+    skos:historyNote "https://orcid.org/0000-0001-2345-6789 Sofia Garcia"@en ;
     skos:prefLabel "Test-of-Voc4Cat"@en ;
     dcat:contactPoint "Sofia Garcia (orcid:0000-0001-2345-6789)" ;
 .


### PR DESCRIPTION
Updated files were created by (i) converting the old files to xlsx and (ii) converting xlsx back to turtle.

Closes #57