### PR TITLE
Use idrange-config when converting to xlsx

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -82,8 +82,9 @@ jobs:
           mv publish/dev/index.html publish/
 
       - name: Run voc4cat (build current Excel file)
+        # Passing the config is important to make use of the prefixes therein.
         run: |
-          voc4cat convert --logfile publish/dev/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/dev/
+          voc4cat convert --config _main_branch/idranges.toml --logfile publish/dev/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/dev/
 
       - name: Deploy updated gh-pages content
         # This replaces all prior content in gh-pages branch. But we have

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,8 +80,9 @@ jobs:
           mv publish/latest/index.html publish/
 
       - name: Run voc4cat (build current Excel file)
+        # Passing the config is important to make use of the prefixes therein.
         run: |
-          voc4cat convert --logfile publish/latest/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/latest/
+          voc4cat convert --config _main_branch/idranges.toml --logfile publish/latest/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/latest/
 
       - name: Copy release to release-name directory
         run: |

--- a/justfile
+++ b/justfile
@@ -71,7 +71,7 @@ docs:
 # Rebuild the xlsx file from the joined ttl file.
 xlsx:
   @rm -f outbox/voc4cat.xlsx
-  @voc4cat convert --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/
+  @voc4cat convert --config _main_branch/idranges.toml --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/
 
 # Run all steps as in gh-actions: check xlsx, convert to SKOS, build docs, re-build xlsx
 all: check convert docs xlsx

--- a/vocabularies/vocab_example/0000001.ttl
+++ b/vocabularies/vocab_example/0000001.ttl
@@ -16,4 +16,3 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:relatedMatch <https://example.org/test/0000003> ;
     skos:topConceptOf <https://example.org/test/> ;
 .
-

--- a/vocabularies/vocab_example/0000002.ttl
+++ b/vocabularies/vocab_example/0000002.ttl
@@ -16,4 +16,3 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:inScheme <https://example.org/test/> ;
     skos:prefLabel "Compact Universal Resource Locator"@en ;
 .
-

--- a/vocabularies/vocab_example/0000003.ttl
+++ b/vocabularies/vocab_example/0000003.ttl
@@ -14,4 +14,3 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "Internationalized Resource Identifier"@en ;
     skos:topConceptOf <https://example.org/test/> ;
 .
-

--- a/vocabularies/vocab_example/0000010.ttl
+++ b/vocabularies/vocab_example/0000010.ttl
@@ -17,4 +17,3 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <https://example.org/test/0000003> ;
     skos:prefLabel "Linked data term"@en ;
 .
-

--- a/vocabularies/vocab_example/concept_scheme.ttl
+++ b/vocabularies/vocab_example/concept_scheme.ttl
@@ -21,4 +21,3 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "Test-of-Voc4Cat"@en ;
     dcat:contactPoint "Sofia Garcia (orcid:0000-0001-2345-6789)" ;
 .
-


### PR DESCRIPTION
This fixes the commands in the gh-actions workflows as well as in the justfile.

In addition, some ttl-files are changed because a newer version of rdflib is used after removing an unnecessary upper-version bound for the documentation generator [pyLODE2](https://github.com/dalito/pyLODE/commit/0b4e31bed0598ef340ec20a6f923638e261cce97).

Closes #78